### PR TITLE
fix(docs): Add bun install command for dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ You'll need to update values in the `.env` file to match your configuration, but
 ## 3. Run the server
 
 ```bash
+bun install
 bun run src/index.ts
 ```
 


### PR DESCRIPTION
As I went through the quickstart, this command:
```bash
bun run src/index.ts
```
threw an error because bun could not find the bcrypt package. I ran 
```bash
bun install
bun run src/index.ts
```
and it worked as expected.